### PR TITLE
Add optional crowbar-applied boolean attribute to schema

### DIFF
--- a/chef/data_bags/crowbar/bc-template-updater.json
+++ b/chef/data_bags/crowbar/bc-template-updater.json
@@ -18,6 +18,7 @@
   "deployment": {
     "updater": {
       "crowbar-revision": 0,
+      "crowbar-applied": false,
       "elements": {},
       "element_states": {
         "updater": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-updater.schema
+++ b/chef/data_bags/crowbar/bc-template-updater.schema
@@ -40,6 +40,7 @@
           "mapping": {
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
+            "crowbar-applied": { "type": "bool" },
             "crowbar-status": { "type": "str" },
             "crowbar-failed": { "type": "str" },
             "crowbar-queued": { "type": "bool" },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -27,4 +27,4 @@ crowbar:
   order: 99
   run_order: 99
   chef_order: 99
-  proposal_schema_version: 2
+  proposal_schema_version: 3


### PR DESCRIPTION
We add a crowbar applied attribute to mark the proposal as applied after
the chef run. This allows the UI to show that the current form of the
proposal has been 'applied' successfully (i.e. chef-client completed the
run w/ success) and that the proposal was not modified after that.

Update the proposal_schema_revision, so we can add the attribute to
schema for ('3rd party') barclamps that currently do not have it.

Refs: crowbar/crowbar#2044 (which adds this attribute to barclamps which
lack it), crowbar/barclamp-crowbar#1068 (which marks the proposa
