### PR TITLE
Implement upgrade state/disable services

### DIFF
--- a/chef/cookbooks/updater/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/updater/recipes/crowbar-upgrade.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: updater
-# Recipe:: upgrade
+# Recipe:: crowbar-upgrade
 #
 # Copyright 2013-2015, SUSE LINUX Products GmbH
 #

--- a/chef/cookbooks/updater/recipes/upgrade.rb
+++ b/chef/cookbooks/updater/recipes/upgrade.rb
@@ -1,0 +1,57 @@
+#
+# Cookbook Name:: updater
+# Recipe:: upgrade
+#
+# Copyright 2013-2015, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# Disable openstack services
+# We don't know which openstack services are enabled on the node and
+# collecting that information via the attributes provided by chef is
+# is rather complicated. So instead we fall back to a simple bash hack
+
+if !node[:updater].has_key?(:upgrade_one_shot_run) || !node[:updater][:upgrade_one_shot_run]
+
+  node[:updater][:upgrade_one_shot_run] = true
+  node.save
+
+
+  bash "disable_openstack_services" do
+    code <<-EOF
+      for i in /etc/init.d/openstack-* /etc/init.d/openvswitch-switch /etc/init.d/ovs-usurp-config-* /etc/init.d/drbd /etc/init.d/openais;
+      do
+        if test -e $i
+        then
+          initscript=`basename $i`
+          insserv -r $initscript
+        fi
+      done
+    EOF
+    only_if { node[:platform] == "suse" }
+  end
+
+  # Disable crowbar-join
+  service "crowbar_join" do
+    action :disable
+    only_if { node[:platform] == "suse" }
+  end
+
+  # Disable chef-client
+  service "chef-client" do
+    action [:disable, :stop]
+    only_if { node[:platform] == "suse" }
+  end
+end

--- a/chef/data_bags/crowbar/bc-template-updater.json
+++ b/chef/data_bags/crowbar/bc-template-updater.json
@@ -12,20 +12,27 @@
           "include_reboot_patches": false
         }
       },
-      "one_shot_run": false
+      "one_shot_run": false,
+      "upgrade_one_shot_run": false
     }
   },
   "deployment": {
     "updater": {
-      "crowbar-revision": 0,
+      "crowbar-revision": 1,
       "crowbar-applied": false,
       "elements": {},
       "element_states": {
-        "updater": [ "readying", "ready", "applying" ]
+        "updater": [ "readying", "ready", "applying" ],
+        "updater-upgrade": [ "readying", "ready", "applying" ]
       },
       "element_order": [
-        [ "updater" ]
+        [ "updater" ],
+        [ "updater-upgrade" ]
       ],
+      "element_run_list_order": {
+        "updater": 40,
+        "updater-upgrade": 2000
+      },
       "config": {
         "environment": "updater-config-base",
         "mode": "full",

--- a/chef/data_bags/crowbar/bc-template-updater.json
+++ b/chef/data_bags/crowbar/bc-template-updater.json
@@ -23,15 +23,15 @@
       "elements": {},
       "element_states": {
         "updater": [ "readying", "ready", "applying" ],
-        "updater-upgrade": [ "readying", "ready", "applying" ]
+        "updater-crowbar-upgrade": [ "readying", "ready", "applying" ]
       },
       "element_order": [
         [ "updater" ],
-        [ "updater-upgrade" ]
+        [ "updater-crowbar-upgrade" ]
       ],
       "element_run_list_order": {
         "updater": 40,
-        "updater-upgrade": 2000
+        "updater-crowbar-upgrade": 2000
       },
       "config": {
         "environment": "updater-config-base",

--- a/chef/data_bags/crowbar/bc-template-updater.schema
+++ b/chef/data_bags/crowbar/bc-template-updater.schema
@@ -25,7 +25,8 @@
                 }
               }
             },
-            "one_shot_run": { "type": "bool" }
+            "one_shot_run": { "type": "bool" },
+            "upgrade_one_shot_run": { "type": "bool" }
           }
         }
       }
@@ -72,6 +73,16 @@
                 "type": "seq",
                 "sequence": [ { "type": "str" } ]
               } ]
+            },
+            "element_run_list_order": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                = : {
+                  "type": "int",
+                  "required": true
+                }
+              }
             },
             "config": {
               "type": "map",

--- a/chef/data_bags/crowbar/migrate/updater/001_add_updater-upgrade-role.rb
+++ b/chef/data_bags/crowbar/migrate/updater/001_add_updater-upgrade-role.rb
@@ -1,0 +1,16 @@
+def upgrade ta, td, a, d
+  a['upgrade_one_shot'] = ta['upgrade_one_shot']
+  d['element_states'] = td['element_states']
+  d['element_order'] = td['element_order']
+  d['element_run_list_order'] = td['element_run_list_order']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('upgrade_one_shot')
+  d['element_states'] = td['element_states']
+  d['element_order'] = td['element_order']
+  d['element_run_list_order'] = td['element_run_list_order']
+  return a, d
+end
+

--- a/chef/roles/updater-crowbar-upgrade.rb
+++ b/chef/roles/updater-crowbar-upgrade.rb
@@ -17,9 +17,9 @@
 # limitations under the License.
 #
 
-name "updater-upgrade"
+name "updater-crowbar-upgrade"
 description "Prepare nodes for the cloud upgrade"
 
 run_list(
-  "recipe[updater::upgrade]"
+  "recipe[updater::crowbar-upgrade]"
 )

--- a/chef/roles/updater-upgrade.rb
+++ b/chef/roles/updater-upgrade.rb
@@ -1,4 +1,7 @@
 #
+# Cookbook Name:: updater
+# Role:: updater
+#
 # Copyright 2013-2014, SUSE LINUX Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,18 +17,9 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'updater'
-  display: 'Updater'
-  description: 'System Package Updater'
-  version: 0
-  user_managed: true
-  member:
-    - 'crowbar'
+name "updater-upgrade"
+description "Prepare nodes for the cloud upgrade"
 
-crowbar:
-  layout: 1
-  order: 99
-  run_order: 2000
-  chef_order: 2000
-  proposal_schema_version: 3
+run_list(
+  "recipe[updater::upgrade]"
+)

--- a/crowbar_framework/app/models/updater_service.rb
+++ b/crowbar_framework/app/models/updater_service.rb
@@ -31,7 +31,7 @@ class UpdaterService < ServiceObject
             "windows" => "/.*/"
           }
         },
-        "updater-upgrade" => {
+        "updater-crowbar-upgrade" => {
           "unique" => false,
           "count" => -1,
           "admin" => false,
@@ -72,27 +72,15 @@ class UpdaterService < ServiceObject
           @logger.debug("Updater apply_role_post_chef_call: delete [:updater][:one_shot_run] for #{node.name} (#{node[:updater].inspect}")
           node.save
         end
-        if node.role? "updater-upgrade"
-        node[:updater][:upgrade_one_shot_run] = false
-        @logger.debug("Updater apply_role_post_chef_call: delete [:updater][:upgrade_one_shot_run] for #{node.name} (#{node[:updater].inspect}")
-        node.save
+        if node.role? "updater-crowbar-upgrade"
+          node[:updater][:upgrade_one_shot_run] = false
+          @logger.debug("Updater apply_role_post_chef_call: delete [:updater][:upgrade_one_shot_run] for #{node.name} (#{node[:updater].inspect}")
+
+          # By modifying the runlist we ensure that only upgrade related recipes are executed
+          node.run_list.run_list_items.clear
+          node.run_list.run_list_items << "role[updater-crowbar-upgrade]"
+          node.save
         end
-      end
-    end
-    all_nodes.each do |n|
-      node = NodeObject.find_node_by_name n
-      if node.role? "updater-upgrade"
-        role_name = NodeObject.make_role_name(node.name)
-        storage_role = RoleObject.find_role_by_name(role_name)
-        storage_role = role
-        # TODO: Make sure that storage_role.name does not already exist
-        storage_role.name= role.name+"-upgrade_storage"
-        storage_role.save
-        node.delete_from_run_list(role.name)
-        # TODO: Find out if there can be more than one role on the run_list -
-        # If so, handle that in a proper way
-        node.add_to_run_list("updater-upgrade", 2000)
-        node.save
       end
     end
 
@@ -110,19 +98,12 @@ class UpdaterService < ServiceObject
   def apply_role_post_chef_call(old_role, role, all_nodes)
     all_nodes.each do |n|
       node = NodeObject.find_node_by_name n
-      if node.role? "updater-upgrade"
-        # Put together storage role name
-        role_name = NodeObject.make_role_name(node.name)
-        role  = RoleObject.find_role_by_name(role_name+"-upgrade_storage")
-        role.name = role_name
-        node.delete_from_run_list("updater-upgrade")
-#        priority = runlist_priority_map[item] || local_chef_order
-        priority = 1
-        # FIXME: Not sure if this works, and if it does, find solution for priority
-        node.add_to_run_list(role.name, priority)
-        node.crowbar["state"] = "upgrade"
-        # Cleanup storage role
-        RoleObject.destroy(role_name+"-upgrade_storage")
+      if node.role? "updater-crowbar-upgrade"
+        # After the upgrade recipes were executed, return the original role to runlist
+        node_role_name = NodeObject.make_role_name(node.name)
+        node.run_list.run_list_items.clear
+        node.run_list.run_list_items << "role[#{node_role_name}]"
+        node.crowbar["state"] = "crowbar-upgrade"
         node.save
       end
     end

--- a/crowbar_framework/app/models/updater_service.rb
+++ b/crowbar_framework/app/models/updater_service.rb
@@ -30,6 +30,14 @@ class UpdaterService < ServiceObject
           "exclude_platform" => {
             "windows" => "/.*/"
           }
+        },
+        "updater-upgrade" => {
+          "unique" => false,
+          "count" => -1,
+          "admin" => false,
+          "exclude_platform" => {
+            "windows" => "/.*/"
+          }
         }
       }
     end
@@ -55,15 +63,39 @@ class UpdaterService < ServiceObject
 
   def apply_role_pre_chef_call(old_role, role, all_nodes)
     @logger.debug("Updater apply_role_post_chef_call: entering #{all_nodes.inspect}")
-    # Remove [:updater][:one_shot_run] flag from node
+    # Remove [:updater][...] flags from node
     all_nodes.each do |n|
       node = NodeObject.find_node_by_name n
       unless node[:updater].nil?
-        node[:updater][:one_shot_run] = false
-        @logger.debug("Updater apply_role_post_chef_call: delete [:updater][:one_shot_run] for #{node.name} (#{node[:updater].inspect}")
+        if node.role? "updater"
+          node[:updater][:one_shot_run] = false
+          @logger.debug("Updater apply_role_post_chef_call: delete [:updater][:one_shot_run] for #{node.name} (#{node[:updater].inspect}")
+          node.save
+        end
+        if node.role? "updater-upgrade"
+        node[:updater][:upgrade_one_shot_run] = false
+        @logger.debug("Updater apply_role_post_chef_call: delete [:updater][:upgrade_one_shot_run] for #{node.name} (#{node[:updater].inspect}")
+        node.save
+        end
+      end
+    end
+    all_nodes.each do |n|
+      node = NodeObject.find_node_by_name n
+      if node.role? "updater-upgrade"
+        role_name = NodeObject.make_role_name(node.name)
+        storage_role = RoleObject.find_role_by_name(role_name)
+        storage_role = role
+        # TODO: Make sure that storage_role.name does not already exist
+        storage_role.name= role.name+"-upgrade_storage"
+        storage_role.save
+        node.delete_from_run_list(role.name)
+        # TODO: Find out if there can be more than one role on the run_list -
+        # If so, handle that in a proper way
+        node.add_to_run_list("updater-upgrade", 2000)
         node.save
       end
     end
+
    ## Rather work directly on Chef::Node objects to avoid Crowbar's deep_merge stuff
    #ChefObject.query_chef.search("node")[0].each do |node|
    #  if node.has_key?(:updater) && node[:updater].has_key?(:one_shot_run)
@@ -74,6 +106,30 @@ class UpdaterService < ServiceObject
    #end
     @logger.debug("Updater apply_role_post_chef_call: exiting")
   end
+
+  def apply_role_post_chef_call(old_role, role, all_nodes)
+    all_nodes.each do |n|
+      node = NodeObject.find_node_by_name n
+      if node.role? "updater-upgrade"
+        # Put together storage role name
+        role_name = NodeObject.make_role_name(node.name)
+        role  = RoleObject.find_role_by_name(role_name+"-upgrade_storage")
+        role.name = role_name
+        node.delete_from_run_list("updater-upgrade")
+#        priority = runlist_priority_map[item] || local_chef_order
+        priority = 1
+        # FIXME: Not sure if this works, and if it does, find solution for priority
+        node.add_to_run_list(role.name, priority)
+        node.crowbar["state"] = "upgrade"
+        # Cleanup storage role
+        RoleObject.destroy(role_name+"-upgrade_storage")
+        node.save
+      end
+    end
+    role_name = role.name
+    Rails.logger.info " updater_service: role_name: #{role_name}"
+  end
+
 
   def oneshot?
     true


### PR DESCRIPTION
Add a role to the updater barclamp that allows to disable
all openstack services and crowbar_join and disables and
stops chef-client

(cherry picked from commit 71f950f7b55753e01cafd6f1b936f699be0aadec)

Original PR (with comments): https://github.com/crowbar/barclamp-updater/pull/11
